### PR TITLE
CSS fix

### DIFF
--- a/_includes/layouts/main.njk
+++ b/_includes/layouts/main.njk
@@ -2,7 +2,6 @@
 title: Rehydrate
 pageHeading: Rehydrate
 ---
-<!doctype html>
 <html lang="en">
   <head>
     <title>{{ title }}</title>

--- a/app.css
+++ b/app.css
@@ -87,6 +87,8 @@ ul {
   height: auto;
   image-orientation: from-image;
   object-fit: contain;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 
 .media-list .pane h4:first-child {
@@ -179,6 +181,8 @@ header h1 {
 
 .episode-player {
   margin-bottom: 1em;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 .episode-title {

--- a/rss.xml.njk
+++ b/rss.xml.njk
@@ -7,7 +7,7 @@ metadata:
     name: Jim, Dan, Tim, and Amin
     email: rehydrate@fastmail.com
   description: A podcast about Liu Cixin's Three-Body Problem and the rest of the Remembrance of Earth's Past series.
-  imageURL: https://rehydrate.space/media/small-findings.jpg
+  imageURL: https://rehydrate.space/media/rehydrate-logo.png
   feed:
     filename: rss.xml
     path: rss.xml


### PR DESCRIPTION
The main thing here is a fix for all of the CSS being ignored. Digital Ocean Spaces serves `app.css` as `text/plain` instead of `text/css`. Seems that if we set `doctype` to `html`, browsers ignore CSS without the correct content-type. Without the doctype, the browsers process the CSS rules.